### PR TITLE
feat: Add script to dynamically select docker or podman

### DIFF
--- a/hpc-build-image
+++ b/hpc-build-image
@@ -1,2 +1,42 @@
 #!/usr/bin/env bash
-docker build -t hpcimage .
+
+## Exit Codes
+# 0 - everything run correctly
+# 1 - Neither docker or podman are installed or can be used
+
+
+use_docker=0
+use_podman=0
+
+# Check if docker is installed on the user's machine
+if [ -x "$(command -v docker)" ]; then
+    # Check if the user's machines has unified cgroup hierarchy
+    # This check is sufficient as the structure of the /sys/fs/cgroup
+    # directory differs from cgroup v1 to cgroup v2. 
+    if [ -f "/sys/fs/cgroup/cgroup.controllers" ]; then
+        echo "Docker doesn't support cgroup v2 yet."
+    else
+        use_docker=1
+    fi
+fi
+# Check if podman is installed
+if [ -x "$(command -v podman)" ]; then
+    # Check if docker is also installed and checked for use
+    # Installation should default to docker and use podman 
+    # only when cgroup v2 is enabled on the host machine
+    if [ "$use_docker"  == "0" ]; then 
+        use_podman=1
+    fi
+fi
+
+if [ "$use_docker" == "1" ] && [ "$use_podman" == "0" ]; then
+    `echo "$(command -v docker)"` `echo "build -t hpcimage ."`
+elif [ "$use_docker" == "0" ] && [ "$use_podman" == "1" ]; then
+    #Check if podman-compose is installed
+    `echo "$(command -v podman)"` `echo "build -t hpcimage ."`
+elif [ "$use_docker" == "0" ] && [ "$use_podman" == "0" ]; then
+  echo "Neither docker or podman is installed or can be used. Exiting abruptly..."
+  exit 1
+fi
+
+exit 0

--- a/hpc-create-container
+++ b/hpc-create-container
@@ -33,7 +33,7 @@ if [ "$use_docker" == "1" ] && [ "$use_podman" == "0" ]; then
     `echo "$(command -v docker)"` `echo "create -ti --name hpc -v$(pwd)/..:/home/csal/pds hpcimage"`
 elif [ "$use_docker" == "0" ] && [ "$use_podman" == "1" ]; then
     #Check if podman-compose is installed
-    `echo "$(command -v podman)"` `echo "create -ti --name hpc -v$(pwd)/..:/home/csal/pds hpcimage"`
+    `echo "$(command -v podman)"` `echo "create -ti --name hpc -v$(pwd)/..:/home/csal/pds:rshared hpcimage"`
 elif [ "$use_docker" == "0" ] && [ "$use_podman" == "0" ]; then
   echo "Neither docker or podman is installed or can be used. Exiting abruptly..."
   exit 1

--- a/hpc-create-container
+++ b/hpc-create-container
@@ -1,2 +1,42 @@
 #!/usr/bin/env bash
-docker create -ti --name hpc -v$(pwd)/..:/home/csal/pds hpcimage
+
+## Exit Codes
+# 0 - everything run correctly
+# 1 - Neither docker or podman are installed or can be used
+
+
+use_docker=0
+use_podman=0
+
+# Check if docker is installed on the user's machine
+if [ -x "$(command -v docker)" ]; then
+    # Check if the user's machines has unified cgroup hierarchy
+    # This check is sufficient as the structure of the /sys/fs/cgroup
+    # directory differs from cgroup v1 to cgroup v2. 
+    if [ -f "/sys/fs/cgroup/cgroup.controllers" ]; then
+        echo "Docker doesn't support cgroup v2 yet."
+    else
+        use_docker=1
+    fi
+fi
+# Check if podman is installed
+if [ -x "$(command -v podman)" ]; then
+    # Check if docker is also installed and checked for use
+    # Installation should default to docker and use podman 
+    # only when cgroup v2 is enabled on the host machine
+    if [ "$use_docker"  == "0" ]; then 
+        use_podman=1
+    fi
+fi
+
+if [ "$use_docker" == "1" ] && [ "$use_podman" == "0" ]; then
+    `echo "$(command -v docker)"` `echo "create -ti --name hpc -v$(pwd)/..:/home/csal/pds hpcimage"`
+elif [ "$use_docker" == "0" ] && [ "$use_podman" == "1" ]; then
+    #Check if podman-compose is installed
+    `echo "$(command -v podman)"` `echo "create -ti --name hpc -v$(pwd)/..:/home/csal/pds hpcimage"`
+elif [ "$use_docker" == "0" ] && [ "$use_podman" == "0" ]; then
+  echo "Neither docker or podman is installed or can be used. Exiting abruptly..."
+  exit 1
+fi
+
+exit 0

--- a/hpc-start-container
+++ b/hpc-start-container
@@ -1,3 +1,44 @@
 #!/usr/bin/env bash
-docker start hpc
-docker exec -it hpc bash
+
+## Exit Codes
+# 0 - everything run correctly
+# 1 - Neither docker or podman are installed or can be used
+
+
+use_docker=0
+use_podman=0
+
+# Check if docker is installed on the user's machine
+if [ -x "$(command -v docker)" ]; then
+    # Check if the user's machines has unified cgroup hierarchy
+    # This check is sufficient as the structure of the /sys/fs/cgroup
+    # directory differs from cgroup v1 to cgroup v2. 
+    if [ -f "/sys/fs/cgroup/cgroup.controllers" ]; then
+        echo "Docker doesn't support cgroup v2 yet."
+    else
+        use_docker=1
+    fi
+fi
+# Check if podman is installed
+if [ -x "$(command -v podman)" ]; then
+    # Check if docker is also installed and checked for use
+    # Installation should default to docker and use podman 
+    # only when cgroup v2 is enabled on the host machine
+    if [ "$use_docker"  == "0" ]; then 
+        use_podman=1
+    fi
+fi
+
+if [ "$use_docker" == "1" ] && [ "$use_podman" == "0" ]; then
+    `echo "$(command -v docker)"` `echo "start hpc"`
+    `echo "$(command -v docker)"` `echo "exec -it hpc bash"`
+elif [ "$use_docker" == "0" ] && [ "$use_podman" == "1" ]; then
+    #Check if podman-compose is installed
+    `echo "$(command -v podman)"` `echo "start hpc"`
+    `echo "$(command -v podman)"` `echo "exec -it hpc bash"`
+elif [ "$use_docker" == "0" ] && [ "$use_podman" == "0" ]; then
+  echo "Neither docker or podman is installed or can be used. Exiting abruptly..."
+  exit 1
+fi
+
+exit 0

--- a/hpc-uninstall
+++ b/hpc-uninstall
@@ -1,3 +1,44 @@
 #!/usr/bin/env bash
-docker container rm hpc -f &&
-docker image rm hpcimage -f
+
+## Exit Codes
+# 0 - everything run correctly
+# 1 - Neither docker or podman are installed or can be used
+
+
+use_docker=0
+use_podman=0
+
+# Check if docker is installed on the user's machine
+if [ -x "$(command -v docker)" ]; then
+    # Check if the user's machines has unified cgroup hierarchy
+    # This check is sufficient as the structure of the /sys/fs/cgroup
+    # directory differs from cgroup v1 to cgroup v2. 
+    if [ -f "/sys/fs/cgroup/cgroup.controllers" ]; then
+        echo "Docker doesn't support cgroup v2 yet."
+    else
+        use_docker=1
+    fi
+fi
+# Check if podman is installed
+if [ -x "$(command -v podman)" ]; then
+    # Check if docker is also installed and checked for use
+    # Installation should default to docker and use podman 
+    # only when cgroup v2 is enabled on the host machine
+    if [ "$use_docker"  == "0" ]; then 
+        use_podman=1
+    fi
+fi
+
+if [ "$use_docker" == "1" ] && [ "$use_podman" == "0" ]; then
+    `echo "$(command -v docker)"` `echo "container rm hpc -f"` && \
+    `echo "$(command -v docker)"` `echo "image rm hpcimage -f"`
+elif [ "$use_docker" == "0" ] && [ "$use_podman" == "1" ]; then
+    #Check if podman-compose is installed
+    `echo "$(command -v podman)"` `echo "container rm hpc -f"`
+    `echo "$(command -v podman)"` `echo "image rm hpcimage"` && \
+elif [ "$use_docker" == "0" ] && [ "$use_podman" == "0" ]; then
+  echo "Neither docker or podman is installed or can be used. Exiting abruptly..."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
This script is created to check for the container engine the user
is running. After checking for the engine it also checks the cgroup API
they are using. If they are using cgroup v2 and they have docker installed,
the script will automatically switch to podman. If the user has cgroup v1 enabled,
and the docker engine is installed, the script will use docker. Else it will default to
podman. If neither is installed or can be used, it will exit with non 0 code. Podman can
be used with both cgroup API versions as it is daemon-less and run rootless by default.
This script is necessary for developers that aren't running  the docker engine or that
their OS doesn't support the docker engine like some Linux distros (eg Fedora).