### PR TITLE
Add support for Github Actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,26 @@
+name: Publish Docker image
+on:
+  push:
+    branches:
+      - master
+jobs:
+  push_to_dockerhub:
+    name: Push Docker image to docker hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: |
+            authcsal/docker:latestgithub


### PR DESCRIPTION
This adds a CI pipeline that builds the image in github actions and publishes it to docker hub registry. 

This will automate the image publication and the maintainers will not have to manually upload the image

The pipeline will only run on the master branch. If creating an image on pull requests is something you want, I can also work on that.