### PR TITLE
Add support for passing arguments to a command invoked via docker run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,5 +116,6 @@ COPY Welcome $HOME/.welcome
 RUN echo "cat $HOME/.welcome" >> $HOME/.bashrc
 
 # Start bash login shell
-ENTRYPOINT ["/bin/bash", "-l", "-c"]
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["/bin/bash", "-i"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# first arg is `-f` or `--some-option`
+# or there are no args
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+	# docker run bash -c 'echo hi'
+	exec bash "$@"
+fi
+
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 # first arg is `-f` or `--some-option`
 # or there are no args
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
-	# docker run bash -c 'echo hi'
+	# docker run hpcimage -c 'echo hi'
 	exec bash "$@"
 fi
 


### PR DESCRIPTION
This request follows the issue #5.

The proposed solution:
 - An argument parsing script is added as enrtypoint, to support argument passing to invoked commands.
 - A small change in Dockerfile to copy and invoke the script